### PR TITLE
Add DEPENDS.txt to track dependencies for TeX Live

### DIFF
--- a/DEPENDS.txt
+++ b/DEPENDS.txt
@@ -1,0 +1,1 @@
+hard calc ifthen ifmtarg


### PR DESCRIPTION
This file is [specifically supported by TeX Live](https://tug.org/texlive/pkgcontrib.html#deps) to track the dependencies of a package, and the TL dependency information is used by other tools. Declaring the dependencies here makes that information available to tools - in particular, the dependency on `ifmtarg`, which is not included by default as a package in a LaTeX distribution.

The packages `calc` and `ifthen` are both included by default in every LaTeX distribution, but there's not much guidance online about if you need to include such packages or not. Since they are `Require`d, I've included them.

---

This is the outcome of an issue I noticed with the Guix package set, which wasn't installing `ifmtarg` as a dependency of this package. They claim that it's the responsibility of TL to record dependencies, and TL claims it's the responsibility of the package author. I'm not sure who's correct, but I think it's not a bad idea to declare dependencies here for both TL and Guix to use.